### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Follow below instructions to generate documentation from `DOCUMENTATION` string 
 * `make` utility <br/><br/>
  Make utility is required to generate html docs. Install `make` utility by running below command on Ubuntu.
 ```sh
-sudo apt-get -y install make 
+sudo apt-get --no-install-recommends install -y make 
 ```
 * `python` version 2.7.X<br/><br/>
  Run below command to install `python`.
 ```sh
-sudo apt-get -y install python2.7
+sudo apt-get --no-install-recommends install -y python2.7
 ```
 Check python installation by running below command.
 ```sh
@@ -24,7 +24,7 @@ python --version
 * Install `pip`<br/><br/>
  Run below command to install `pip` and other packages.
 ```sh
-sudo apt-get -y install python-pip python-dev dos2unix
+sudo apt-get --no-install-recommends install -y python-pip python-dev dos2unix
 ```
 
 * Install sphinx and theme: 

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -29,8 +29,8 @@ Due to dependencies (for example ansible -> paramiko -> pynacl -> libffi):
 
 .. code:: bash
 
-    sudo apt update
-    sudo apt install build-essential libssl-dev libffi-dev python-dev
+    sudo apt-get update 
+    sudo apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev python-dev
 
 Common Environment setup
 ````````````````````````

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -146,10 +146,10 @@ To configure the PPA on your machine and install ansible run these commands:
 .. code-block:: bash
 
     $ sudo apt-get update
-    $ sudo apt-get install software-properties-common
+    $ sudo apt-get install -y --no-install-recommends software-properties-common
     $ sudo apt-add-repository ppa:ansible/ansible
     $ sudo apt-get update
-    $ sudo apt-get install ansible
+    $ sudo apt-get install -y --no-install-recommends ansible
 
 .. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties".
 
@@ -178,7 +178,7 @@ Then run these commands:
 
     $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
     $ sudo apt-get update
-    $ sudo apt-get install ansible
+    $ sudo apt-get install -y --no-install-recommends ansible
 
 .. note:: This method has been verified with the Trusty sources in Debian Jessie and Stretch but may not be supported in earlier versions.
 

--- a/docs/docsite/rst/scenario_guides/guide_cloudstack.rst
+++ b/docs/docsite/rst/scenario_guides/guide_cloudstack.rst
@@ -25,7 +25,7 @@ Or alternatively starting with Debian 9 and Ubuntu 16.04:
 
 .. code-block:: bash
 
-    $ sudo apt install python-cs
+    $ sudo apt-get install -y --no-install-recommends python-cs
 
 .. note:: cs also includes a command line interface for ad-hoc interaction with the CloudStack API e.g. ``$ cs listVirtualMachines state=Running``.
 

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -45,7 +45,7 @@ can be run in the bash terminal:
 .. code-block:: shell
 
     sudo apt-get update
-    sudo apt-get install python-pip git libffi-dev libssl-dev -y
+    sudo apt-get install -y --no-install-recommends python-pip git libffi-dev libssl-dev -y
     pip install ansible pywinrm
 
 To run Ansible from source instead of a release on the WSL, simply uninstall the pip

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -293,7 +293,7 @@ Some system dependencies that must be installed prior to using Kerberos. The scr
     yum -y install python-devel krb5-devel krb5-libs krb5-workstation
 
     # Via Apt (Ubuntu)
-    sudo apt-get install python-dev libkrb5-dev krb5-user
+    sudo apt-get install -y --no-install-recommends python-dev libkrb5-dev krb5-user
 
     # Via Portage (Gentoo)
     emerge -av app-crypt/mit-krb5

--- a/lib/ansible/galaxy/data/container/.travis.yml
+++ b/lib/ansible/galaxy/data/container/.travis.yml
@@ -8,7 +8,7 @@ services:
 before_install:
   - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
   - sudo apt-get update -qq
-  - sudo apt-get install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine
+  - sudo apt-get --no-install-recommends install -y -o Dpkg::Options::="--force-confold" --force-yes docker-engine
 
 install:
   # Install the latest Ansible Container and Ansible

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -25,7 +25,7 @@ version_added: "2.0"
 description:
     - Manage the network devices. Create, modify and manage various connection and device type e.g., ethernet, teams, bonds, vlans etc.
     - "On CentOS and Fedora like systems, install dependencies as 'yum/dnf install -y python-gobject NetworkManager-glib'"
-    - "On Ubuntu and Debian like systems, install dependencies as 'apt-get install -y libnm-glib-dev'"
+    - "On Ubuntu and Debian like systems, install dependencies as 'apt-get --no-install-recommends install -y libnm-glib-dev'"
 options:
     state:
         description:

--- a/lib/ansible/modules/network/f5/bigip_iapplx_package.py
+++ b/lib/ansible/modules/network/f5/bigip_iapplx_package.py
@@ -39,7 +39,7 @@ options:
 notes:
   - Requires the rpm tool be installed on the host. This can be accomplished through
     different ways on each platform. On Debian based systems with C(apt);
-    C(apt-get install rpm). On Mac with C(brew); C(brew install rpm).
+    C(apt-get install -y --no-install-recommends rpm). On Mac with C(brew); C(brew install rpm).
     This command is already present on RedHat based systems.
   - Requires BIG-IP >= 12.1.0 because the required functionality is missing
     on versions earlier than that.

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -362,7 +362,7 @@ def package_status(m, pkgname, version, cache, state):
                 m.fail_json(msg="No package matching '%s' is available" % pkgname)
             except AttributeError:
                 # python-apt version too old to detect virtual packages
-                # mark as upgradable and let apt-get install deal with it
+                # mark as upgradable and let apt-get install -y --no-install-recommends deal with it
                 return False, False, True, False
         else:
             return False, False, False, False

--- a/lib/ansible/modules/packaging/os/apt_rpm.py
+++ b/lib/ansible/modules/packaging/os/apt_rpm.py
@@ -139,7 +139,7 @@ def install_packages(module, pkgspec):
 
         # apt-rpm always have 0 for exit code if --force is used
         if rc or not installed:
-            module.fail_json(msg="'apt-get -y install %s' failed: %s" % (packages, err))
+            module.fail_json(msg="'apt-get --no-install-recommends install -y %s' failed: %s" % (packages, err))
         else:
             module.exit_json(changed=True, msg="%s present(s)" % packages)
     else:

--- a/lib/ansible/utils/module_docs_fragments/mysql.py
+++ b/lib/ansible/utils/module_docs_fragments/mysql.py
@@ -65,7 +65,7 @@ requirements:
    - MySQLdb
 notes:
    - Requires the MySQLdb Python package on the remote host. For Ubuntu, this
-     is as easy as apt-get install python-mysqldb. (See M(apt).) For CentOS/Fedora, this
+     is as easy as apt-get install -y --no-install-recommends python-mysqldb. (See M(apt).) For CentOS/Fedora, this
      is as easy as yum install MySQL-python. (See M(yum).)
    - Both C(login_password) and C(login_user) are required when you are
      passing credentials. If none are present, the module will attempt to read

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:xenial
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     python-docutils \
     cdbs \
     debootstrap \

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -6,7 +6,7 @@ To create an Ansible DEB package:
 __Note__: You must run this target as root or set `PBUILDER_BIN='sudo pbuilder'`
 
 ```
-apt-get install python-docutils cdbs debootstrap devscripts make pbuilder python-setuptools
+apt-get install -y --no-install-recommends python-docutils cdbs debootstrap devscripts make pbuilder python-setuptools
 git clone https://github.com/ansible/ansible.git
 cd ansible
 DEB_DIST='xenial trusty precise' make deb
@@ -35,5 +35,5 @@ apt-get -fy install
 Or, if you are running Debian Stretch (or later) or Ubuntu Xenial (or later):
 
 ```
-apt install /path/to/<package-file>
+apt-get install -y --no-install-recommends /path/to/<package-file>
 ```

--- a/test/integration/targets/hg/tasks/install.yml
+++ b/test/integration/targets/hg/tasks/install.yml
@@ -18,7 +18,7 @@
 
 # using the apt module prevents autoremove from working, so call apt-get via shell instead
 - name: install mercurial (apt)
-  shell: apt-get -y update && apt-get -y install mercurial
+  shell: apt-get -y update && apt-get --no-install-recommends install -y mercurial
   when: ansible_pkg_mgr == 'apt'
 
 - name: install mercurial (dnf)

--- a/test/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install python
   raw:
-    test -e /usr/bin/python || apt-get -y update && apt-get install -y python-minimal
+    test -e /usr/bin/python || apt-get -y update && apt-get --no-install-recommends install -y python-minimal
   become: yes
 
 # network-integration test are ran with gather_facts: no

--- a/test/runner/Dockerfile
+++ b/test/runner/Dockerfile
@@ -5,7 +5,7 @@ COPY docker/deadsnakes.list /etc/apt/sources.list.d/deadsnakes.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
 
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
     ca-certificates \
     curl \
     gcc \
@@ -53,14 +53,14 @@ RUN ln -s python3   /usr/bin/python
 # For now, we need to manually purge XML docs and other items from a Nuget dir to vastly reduce the image size.
 # See https://github.com/dotnet/dotnet-docker/issues/237 for details.
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
     apt-transport-https \
     && \
     apt-get clean
 ADD https://packages.microsoft.com/config/ubuntu/16.04/prod.list /etc/apt/sources.list.d/microsoft.list
 RUN curl --silent https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
     dotnet-sdk-2.1.4 \
     powershell \
     && \

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -36,7 +36,7 @@ class FakeModule(object):
 
     To prepare a VX:
       sudo apt-get update
-      sudo apt-get install python-setuptools git gcc python-dev libssl-dev
+      sudo apt-get install -y --no-install-recommends python-setuptools git gcc python-dev libssl-dev
       sudo easy_install pip
       sudo pip install ansible nose coverage
       # git the module and cd to the directory

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
     acl \
     apache2 \
     asciidoc \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
     acl \
     apache2 \
     asciidoc \

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
     acl \
     apache2 \
     bzip2 \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>