### PR TITLE
optimize size and time using "--no-cache-dir"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sudo apt-get -y install python-pip python-dev dos2unix
 * Install sphinx and theme: 
 
 ```sh
-pip install sphinx==1.4.8 sphinx_rtd_theme
+pip install --no-cache-dir sphinx==1.4.8 sphinx_rtd_theme
 ```
 
 ## Build the documentation

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -176,7 +176,7 @@ Insecure Platform Warning
 If you receive InsecurePlatformWarning from urllib3, install the
 requests security packages:
 
-    pip install requests[security]
+    pip install --no-cache-dir requests[security]
 
 
 author:
@@ -956,7 +956,7 @@ class AzureInventory(object):
 
 def main():
     if not HAS_AZURE:
-        sys.exit("The Azure python sdk is not installed (try `pip install 'azure>={0}' --upgrade`) - {1}".format(AZURE_MIN_VERSION, HAS_AZURE_EXC))
+        sys.exit("The Azure python sdk is not installed (try `pip install --no-cache-dir 'azure>={0}' --upgrade`) - {1}".format(AZURE_MIN_VERSION, HAS_AZURE_EXC))
 
     AzureInventory()
 

--- a/contrib/inventory/cloudstack.py
+++ b/contrib/inventory/cloudstack.py
@@ -84,7 +84,7 @@ except:
 try:
     from cs import CloudStack, CloudStackException, read_config
 except ImportError:
-    print("Error: CloudStack library must be installed: pip install cs.",
+    print("Error: CloudStack library must be installed: pip install --no-cache-dir cs.",
           file=sys.stderr)
     sys.exit(1)
 

--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -35,7 +35,7 @@ Requirements
 Using the docker modules requires having docker-py <https://docker-py.readthedocs.io/en/stable/>
 installed on the host running Ansible. To install docker-py:
 
-   pip install docker-py
+   pip install --no-cache-dir docker-py
 
 
 Run for Specific Host
@@ -885,7 +885,7 @@ class DockerInventory(object):
 def main():
 
     if not HAS_DOCKER_PY:
-        fail("Failed to import docker-py. Try `pip install docker-py` - %s" % (HAS_DOCKER_ERROR))
+        fail("Failed to import docker-py. Try `pip install --no-cache-dir docker-py` - %s" % (HAS_DOCKER_ERROR))
 
     DockerInventory().run()
 

--- a/contrib/inventory/linode.py
+++ b/contrib/inventory/linode.py
@@ -10,7 +10,7 @@ Linode using the Chube library.
 NOTE: This script assumes Ansible is being executed where Chube is already
 installed and has a valid config at ~/.chube. If not, run:
 
-    pip install chube
+    pip install --no-cache-dir chube
     echo -e "---\napi_key: <YOUR API KEY GOES HERE>" > ~/.chube
 
 For more details, see: https://github.com/exosite/chube

--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -46,7 +46,7 @@ import json
 try:
     from mk_livestatus import Socket
 except ImportError:
-    sys.exit("Error: mk_livestatus is needed. Try something like: pip install python-mk-livestatus")
+    sys.exit("Error: mk_livestatus is needed. Try something like: pip install --no-cache-dir python-mk-livestatus")
 
 
 class NagiosLivestatusInventory(object):

--- a/contrib/inventory/nagios_ndo.py
+++ b/contrib/inventory/nagios_ndo.py
@@ -40,7 +40,7 @@ try:
     from sqlalchemy import text
     from sqlalchemy.engine import create_engine
 except ImportError:
-    sys.exit("Error: SQLAlchemy is needed. Try something like: pip install sqlalchemy")
+    sys.exit("Error: SQLAlchemy is needed. Try something like: pip install --no-cache-dir sqlalchemy")
 
 
 class NagiosNDOInventory(object):

--- a/contrib/inventory/scaleway.py
+++ b/contrib/inventory/scaleway.py
@@ -9,7 +9,7 @@ Shamelessly copied from an existing inventory script.
 
 This script generates an inventory that Ansible can understand by making API requests to Scaleway API
 
-Requires some python libraries, ensure to have them installed when using this script. (pip install requests https://pypi.org/project/requests/)
+Requires some python libraries, ensure to have them installed when using this script. (pip install --no-cache-dir requests https://pypi.org/project/requests/)
 
 Before using this script you may want to modify scaleway.ini config file.
 

--- a/contrib/inventory/softlayer.py
+++ b/contrib/inventory/softlayer.py
@@ -2,7 +2,7 @@
 """
 SoftLayer external inventory script.
 
-The SoftLayer Python API client is required. Use `pip install softlayer` to install it.
+The SoftLayer Python API client is required. Use `pip install --no-cache-dir softlayer` to install it.
 You have a few different options for configuring your username and api_key. You can pass
 environment variables (SL_USERNAME and SL_API_KEY). You can also write INI file to
 ~/.softlayer or /etc/softlayer.conf. For more information see the SL API at:

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -45,7 +45,7 @@ except ImportError:
 try:
     from zabbix_api import ZabbixAPI
 except:
-    print("Error: Zabbix API library must be installed: pip install zabbix-api.",
+    print("Error: Zabbix API library must be installed: pip install --no-cache-dir zabbix-api.",
           file=sys.stderr)
     sys.exit(1)
 

--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -15,7 +15,7 @@ If you do not want to learn the reStructuredText format, you can also [file issu
 
 Note that module documentation can actually be [generated from a DOCUMENTATION docstring][module-docs] in the modules directory, so corrections to modules written as such need to be made in the module source, rather than in docsite source.
 
-To install sphinx and the required theme, install pip and then "pip install sphinx sphinx_rtd_theme"
+To install sphinx and the required theme, install pip and then "pip install --no-cache-dir sphinx sphinx_rtd_theme"
 
 [file issues]: https://github.com/ansible/ansible/issues
 [module-docs]: https://docs.ansible.com/developing_modules.html#documenting-your-module

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -16,7 +16,7 @@
 import sys
 import os
 
-# pip install sphinx_rtd_theme
+# pip install --no-cache-dir sphinx_rtd_theme
 # import sphinx_rtd_theme
 # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -39,10 +39,10 @@ Common Environment setup
 2. Change directory into the repository root dir: ``$ cd ansible``
 3. Create a virtual environment: ``$ python3 -m venv venv`` (or for
    Python 2 ``$ virtualenv venv``. Note, this requires you to install
-   the virtualenv package: ``$ pip install virtualenv``)
+   the virtualenv package: ``$ pip install --no-cache-dir virtualenv``)
 4. Activate the virtual environment: ``$ . venv/bin/activate``
 5. Install development requirements:
-   ``$ pip install -r requirements.txt``
+   ``$ pip install --no-cache-dir -r requirements.txt``
 6. Run the environment setup script for each new dev shell process:
    ``$ . hacking/env-setup``
 
@@ -278,7 +278,7 @@ Unit testing
 
 Unit tests for modules will be appropriately located in ``./test/units/modules``. You must first setup your testing environment. In this example, we're using Python 3.5.
 
-- Install the requirements (outside of your virtual environment): ``$ pip3 install -r ./test/runner/requirements/units.txt``
+- Install the requirements (outside of your virtual environment): ``$ pip3 install --no-cache-dir -r ./test/runner/requirements/units.txt``
 - To run all tests do the following: ``$ ansible-test units --python 3.5`` (you must run ``. hacking/env-setup`` prior to this)
 
 .. note:: Ansible uses pytest for unit testing.

--- a/docs/docsite/rst/dev_guide/developing_modules_general_OLD._rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_OLD._rst
@@ -48,10 +48,10 @@ Environment setup
 2. Change directory into the repository root dir: ``$ cd ansible``
 3. Create a virtual environment: ``$ python3 -m venv venv`` (or for
    Python 2 ``$ virtualenv venv``. Note, this requires you to install
-   the virtualenv package: ``$ pip install virtualenv``)
+   the virtualenv package: ``$ pip install --no-cache-dir virtualenv``)
 4. Activate the virtual environment: ``$ . venv/bin/activate``
 5. Install development requirements:
-   ``$ pip install -r requirements.txt``
+   ``$ pip install --no-cache-dir -r requirements.txt``
 6. Run the environment setup script for each new dev shell process:
    ``$ . hacking/env-setup``
 
@@ -294,7 +294,7 @@ new: true register: testout
 
     Unit tests for modules will be appropriately located in `./test/units/modules`. You must first setup your testing environment. In my case, I'm using Python 3.5.
 
-    - Install the requirements (outside of your virtual environment): `$ pip3 install -r ./test/runner/requirements/units.txt`
+    - Install the requirements (outside of your virtual environment): `$ pip3 install --no-cache-dir -r ./test/runner/requirements/units.txt`
     - To run all tests do the following: `$ ansible-test units --python 3.5` (you must run `. hacking/env-setup` prior to this)
 
     :bulb: Ansible uses pytest for unit testing
@@ -361,10 +361,10 @@ Environment setup
 2. Change directory into the repository root dir: ``$ cd ansible``
 3. Create a virtual environment: ``$ python3 -m venv venv`` (or for
    Python 2 ``$ virtualenv venv``. Note, this requires you to install
-   the virtualenv package: ``$ pip install virtualenv``)
+   the virtualenv package: ``$ pip install --no-cache-dir virtualenv``)
 4. Activate the virtual environment: ``$ . venv/bin/activate``
 5. Install development requirements:
-   ``$ pip install -r requirements.txt``
+   ``$ pip install --no-cache-dir -r requirements.txt``
 6. Run the environment setup script for each new dev shell process:
    ``$ . hacking/env-setup``
 
@@ -607,7 +607,7 @@ new: true register: testout
 
     Unit tests for modules will be appropriately located in `./test/units/modules`. You must first setup your testing environment. In my case, I'm using Python 3.5.
 
-    - Install the requirements (outside of your virtual environment): `$ pip3 install -r ./test/runner/requirements/units.txt`
+    - Install the requirements (outside of your virtual environment): `$ pip3 install --no-cache-dir -r ./test/runner/requirements/units.txt`
     - To run all tests do the following: `$ ansible-test units --python 3.5` (you must run `. hacking/env-setup` prior to this)
 
     :bulb: Ansible uses pytest for unit testing
@@ -674,10 +674,10 @@ Environment setup
 2. Change directory into the repository root dir: ``$ cd ansible``
 3. Create a virtual environment: ``$ python3 -m venv venv`` (or for
    Python 2 ``$ virtualenv venv``. Note, this requires you to install
-   the virtualenv package: ``$ pip install virtualenv``)
+   the virtualenv package: ``$ pip install --no-cache-dir virtualenv``)
 4. Activate the virtual environment: ``$ . venv/bin/activate``
 5. Install development requirements:
-   ``$ pip install -r requirements.txt``
+   ``$ pip install --no-cache-dir -r requirements.txt``
 6. Run the environment setup script for each new dev shell process:
    ``$ . hacking/env-setup``
 
@@ -920,7 +920,7 @@ new: true register: testout
 
     Unit tests for modules will be appropriately located in `./test/units/modules`. You must first setup your testing environment. In my case, I'm using Python 3.5.
 
-    - Install the requirements (outside of your virtual environment): `$ pip3 install -r ./test/runner/requirements/units.txt`
+    - Install the requirements (outside of your virtual environment): `$ pip3 install --no-cache-dir -r ./test/runner/requirements/units.txt`
     - To run all tests do the following: `$ ansible-test units --python 3.5` (you must run `. hacking/env-setup` prior to this)
 
     :bulb: Ansible uses pytest for unit testing
@@ -987,10 +987,10 @@ Environment setup
 2. Change directory into the repository root dir: ``$ cd ansible``
 3. Create a virtual environment: ``$ python3 -m venv venv`` (or for
    Python 2 ``$ virtualenv venv``. Note, this requires you to install
-   the virtualenv package: ``$ pip install virtualenv``)
+   the virtualenv package: ``$ pip install --no-cache-dir virtualenv``)
 4. Activate the virtual environment: ``$ . venv/bin/activate``
 5. Install development requirements:
-   ``$ pip install -r requirements.txt``
+   ``$ pip install --no-cache-dir -r requirements.txt``
 6. Run the environment setup script for each new dev shell process:
    ``$ . hacking/env-setup``
 
@@ -1233,7 +1233,7 @@ new: true register: testout
 
     Unit tests for modules will be appropriately located in `./test/units/modules`. You must first setup your testing environment. In my case, I'm using Python 3.5.
 
-    - Install the requirements (outside of your virtual environment): `$ pip3 install -r ./test/runner/requirements/units.txt`
+    - Install the requirements (outside of your virtual environment): `$ pip3 install --no-cache-dir -r ./test/runner/requirements/units.txt`
     - To run all tests do the following: `$ ansible-test units --python 3.5` (you must run `. hacking/env-setup` prior to this)
 
     :bulb: Ansible uses pytest for unit testing
@@ -1300,10 +1300,10 @@ Environment setup
 2. Change directory into the repository root dir: ``$ cd ansible``
 3. Create a virtual environment: ``$ python3 -m venv venv`` (or for
    Python 2 ``$ virtualenv venv``. Note, this requires you to install
-   the virtualenv package: ``$ pip install virtualenv``)
+   the virtualenv package: ``$ pip install --no-cache-dir virtualenv``)
 4. Activate the virtual environment: ``$ . venv/bin/activate``
 5. Install development requirements:
-   ``$ pip install -r requirements.txt``
+   ``$ pip install --no-cache-dir -r requirements.txt``
 6. Run the environment setup script for each new dev shell process:
    ``$ . hacking/env-setup``
 
@@ -1546,7 +1546,7 @@ new: true register: testout
 
     Unit tests for modules will be appropriately located in `./test/units/modules`. You must first setup your testing environment. In my case, I'm using Python 3.5.
 
-    - Install the requirements (outside of your virtual environment): `$ pip3 install -r ./test/runner/requirements/units.txt`
+    - Install the requirements (outside of your virtual environment): `$ pip3 install --no-cache-dir -r ./test/runner/requirements/units.txt`
     - To run all tests do the following: `$ ansible-test units --python 3.5` (you must run `. hacking/env-setup` prior to this)
 
     :bulb: Ansible uses pytest for unit testing

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -260,15 +260,15 @@ your version of Python, you can get pip by::
 
 Then install Ansible with [1]_::
 
-   $ sudo pip install ansible
+   $ sudo pip install --no-cache-dir ansible
 
 Or if you are looking for the latest development version::
 
-   $ pip install git+https://github.com/ansible/ansible.git@devel
+   $ pip install --no-cache-dir git+https://github.com/ansible/ansible.git@devel
 
 If you are installing on macOS Mavericks, you may encounter some noise from your compiler.  A workaround is to do the following::
 
-   $ sudo CFLAGS=-Qunused-arguments CPPFLAGS=-Qunused-arguments pip install ansible
+   $ sudo CFLAGS=-Qunused-arguments CPPFLAGS=-Qunused-arguments pip install --no-cache-dir ansible
 
 Readers that use virtualenv can also install Ansible under virtualenv, though we'd recommend to not worry about it and just install Ansible globally. Do not use easy_install to install Ansible directly.
 
@@ -331,7 +331,7 @@ If you want to suppress spurious warnings/errors, use::
 
     $ source ./hacking/env-setup -q
 
-If you don't have pip installed in your version of Python, install pip::
+If you don't have pip install --no-cache-dired in your version of Python, install pip::
 
     $ sudo easy_install pip
 
@@ -339,7 +339,7 @@ Ansible also uses the following Python modules that need to be installed [1]_:
 
 .. code-block:: bash
 
-    $ sudo pip install -r ./requirements.txt
+    $ sudo pip install --no-cache-dir -r ./requirements.txt
 
 To update ansible checkouts, use pull-with-rebase so any local changes are replayed.
 
@@ -402,4 +402,4 @@ bugs and feature ideas.
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
 
-.. [1] If you have issues with the "pycrypto" package install on Mac OSX, then you may need to try ``CC=clang sudo -E pip install pycrypto``.
+.. [1] If you have issues with the "pycrypto" package install on Mac OSX, then you may need to try ``CC=clang sudo -E pip install --no-cache-dir pycrypto``.

--- a/docs/docsite/rst/network/user_guide/platform_junos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_junos.rst
@@ -73,7 +73,7 @@ Enabling NETCONF
 
 Before you can use NETCONF to connect to a switch, you must:
 
-- install the ``ncclient`` python package on your control node(s) with ``pip install ncclient``
+- install the ``ncclient`` python package on your control node(s) with ``pip install --no-cache-dir ncclient``
 - enable NETCONF on the Junos OS device(s)
 
 To enable NETCONF on a new switch via Ansible, use the ``junos_netconf`` module via the CLI connection. Set up your platform-level variables just like in the CLI example above, then run a playbook task like this:

--- a/docs/docsite/rst/plugins/lookup/chef_databag.rst
+++ b/docs/docsite/rst/plugins/lookup/chef_databag.rst
@@ -24,7 +24,7 @@ Requirements
 ~~~~~~~~~~~~
 The below requirements are needed on the local master node that executes this lookup.
 
-- pychef (python library https://pychef.readthedocs.io `pip install pychef`
+- pychef (python library https://pychef.readthedocs.io `pip install --no-cache-dir pychef`
 
 
 Parameters

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -162,7 +162,7 @@ You can install Ansible into a virtualenv on the controller quite simply:
 
     $ virtualenv ansible
     $ source ./ansible/bin/activate
-    $ pip install ansible
+    $ pip install --no-cache-dir ansible
 
 If you want to run under Python 3 instead of Python 2 you may want to change that slightly:
 
@@ -170,7 +170,7 @@ If you want to run under Python 3 instead of Python 2 you may want to change tha
 
     $ virtualenv ansible
     $ source ./ansible/bin/activate
-    $ pip3 install ansible
+    $ pip3 install --no-cache-dir ansible
 
 If you need to use any libraries which are not available via pip (for instance, SELinux Python
 bindings on systems such as Red Hat Enterprise Linux or Fedora that have SELinux enabled) then you
@@ -423,7 +423,7 @@ password hashing library is installed:
 
 .. code-block:: shell-session
 
-    pip install passlib
+    pip install --no-cache-dir passlib
 
 Once the library is ready, SHA512 password values can then be generated as follows:
 

--- a/docs/docsite/rst/reference_appendices/python_3_support.rst
+++ b/docs/docsite/rst/reference_appendices/python_3_support.rst
@@ -16,7 +16,7 @@ version of pip.  This will make the default :command:`/usr/bin/ansible` run with
 
 .. code-block:: shell
 
-    $ pip3 install ansible
+    $ pip3 install --no-cache-dir ansible
     $ ansible --version | grep "python version"
       python version = 3.6.2 (default, Sep 22 2017, 08:28:09) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
 

--- a/docs/docsite/rst/scenario_guides/guide_alicloud.rst
+++ b/docs/docsite/rst/scenario_guides/guide_alicloud.rst
@@ -9,7 +9,7 @@ Introduction
 Ansible contains several modules for controlling and managing Alibaba Cloud Compute Services (Alicloud).  This guide
 explains how to use the Alicloud Ansible modules together.
 
-All Alicloud modules require ``footmark`` - install it on your control machine with ``pip install footmark``.
+All Alicloud modules require ``footmark`` - install it on your control machine with ``pip install --no-cache-dir footmark``.
 
 Cloud modules, including Alicloud modules, execute on your local machine (the control machine) with ``connection: local``, rather than on remote machines defined in your hosts.
 

--- a/docs/docsite/rst/scenario_guides/guide_aws.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aws.rst
@@ -11,7 +11,7 @@ section is to explain how to put Ansible modules together (and use inventory scr
 
 Requirements for the AWS modules are minimal.  
 
-All of the modules require and are tested against recent versions of boto.  You'll need this Python module installed on your control machine.  Boto can be installed from your OS distribution or python's "pip install boto".
+All of the modules require and are tested against recent versions of boto.  You'll need this Python module installed on your control machine.  Boto can be installed from your OS distribution or python's "pip install --no-cache-dir boto".
 
 Whereas classically ansible will execute tasks in its host loop against multiple remote machines, most cloud-control steps occur on your local machine with reference to the regions to control.
 

--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -12,14 +12,14 @@ installed on the host running Ansible.
 
 .. code-block:: bash
 
-    $ pip install ansible[azure]
+    $ pip install --no-cache-dir ansible[azure]
 
 If you are running Ansible from source, you can install the dependencies from the
 root directory of the Ansible repo.
 
 .. code-block:: bash
 
-    $ pip install .[azure]
+    $ pip install --no-cache-dir .[azure]
 
 You can also directly run Ansible in `Azure Cloud Shell <https://shell.azure.com>`_, where Ansible is pre-installed.
 

--- a/docs/docsite/rst/scenario_guides/guide_cloudstack.rst
+++ b/docs/docsite/rst/scenario_guides/guide_cloudstack.rst
@@ -19,7 +19,7 @@ You'll need this Python module installed on the execution host, usually your wor
 
 .. code-block:: bash
 
-    $ pip install cs
+    $ pip install --no-cache-dir cs
 
 Or alternatively starting with Debian 9 and Ubuntu 16.04:
 

--- a/docs/docsite/rst/scenario_guides/guide_docker.rst
+++ b/docs/docsite/rst/scenario_guides/guide_docker.rst
@@ -47,13 +47,13 @@ installed on the host running Ansible. You will need to have >= 1.7.0 installed.
 
 .. code-block:: bash
 
-    $ pip install 'docker-py>=1.7.0'
+    $ pip install --no-cache-dir 'docker-py>=1.7.0'
 
 The docker_service module also requires `docker-compose <https://github.com/docker/compose>`_
 
 .. code-block:: bash
 
-   $ pip install 'docker-compose>=1.7.0'
+   $ pip install --no-cache-dir 'docker-compose>=1.7.0'
 
 
 Connecting to the Docker API

--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -15,7 +15,7 @@ The GCE modules all require the apache-libcloud module which you can install fro
 
 .. code-block:: bash
 
-    $ pip install apache-libcloud
+    $ pip install --no-cache-dir apache-libcloud
 
 .. note:: If you're using Ansible on macOS, libcloud also needs to access a CA cert chain. You'll need to download one (you can get one for `here <http://curl.haxx.se/docs/caextract.html>`_.)
 

--- a/docs/docsite/rst/scenario_guides/guide_packet.rst
+++ b/docs/docsite/rst/scenario_guides/guide_packet.rst
@@ -19,7 +19,7 @@ The Packet modules and inventory script connect to the Packet API using the pack
 
 .. code-block:: bash
 
-    $ pip install packet-python
+    $ pip install --no-cache-dir packet-python
 
 In order to check the state of devices created by Ansible on Packet, it's a good idea to install one of the `Packet CLI clients <https://www.packet.net/developers/integrations/api-cli/>`_. Otherwise you can check them via the `Packet portal <https://app.packet.net/portal>`_.
 

--- a/docs/docsite/rst/scenario_guides/guide_rax.rst
+++ b/docs/docsite/rst/scenario_guides/guide_rax.rst
@@ -22,7 +22,7 @@ package repositories, so you will likely need to install it via pip:
 
 .. code-block:: bash
 
-    $ pip install pyrax
+    $ pip install --no-cache-dir pyrax
 
 The following steps will often execute from the control machine against the Rackspace Cloud API, so it makes sense 
 to add localhost to the inventory file.  (Ansible may not require this manual step in the future):

--- a/docs/docsite/rst/scenario_guides/guide_vmware.rst
+++ b/docs/docsite/rst/scenario_guides/guide_vmware.rst
@@ -16,7 +16,7 @@ and vCenter infrastcture. You can install pyVmomi using pip:
 
 .. code-block:: bash
 
-    $ pip install pyvmomi
+    $ pip install --no-cache-dir pyvmomi
 
 
 vmware_guest module

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -17,7 +17,7 @@ a computer on which you use Ansible (it is not required on remote hosts).
 It can usually be installed either via your system package manager, or using
 ``pip``::
 
-    pip install netaddr
+    pip install --no-cache-dir netaddr
 
 .. _netaddr: https://pypi.org/project/netaddr/
 

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -555,7 +555,7 @@ To get redis up and running, perform the equivalent OS commands::
 
     yum install redis
     service redis start
-    pip install redis
+    pip install --no-cache-dir redis
 
 Note that the Python redis library should be installed from pip, the version packaged in EPEL is too old for use by Ansible.
 

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -333,7 +333,7 @@ By default, Ansible uses PyCrypto to encrypt and decrypt vault files. If you hav
 
 .. code-block:: bash
 
-    pip install cryptography
+    pip install --no-cache-dir cryptography
 
 
 .. _vault_format:

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -46,7 +46,7 @@ can be run in the bash terminal:
 
     sudo apt-get update
     sudo apt-get install python-pip git libffi-dev libssl-dev -y
-    pip install ansible pywinrm
+    pip install --no-cache-dir ansible pywinrm
 
 To run Ansible from source instead of a release on the WSL, simply uninstall the pip
 installed version and then clone the git repo.

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -17,7 +17,7 @@ Ansible uses the `pywinrm <https://github.com/diyan/pywinrm>`_ package to
 communicate with Windows servers over WinRM. It is not installed by default
 with the Ansible package, but can be installed by running the following::
 
-   pip install "pywinrm>=0.3.0"
+   pip install --no-cache-dir "pywinrm>=0.3.0"
 
 .. Note:: on distributions with multiple python versions, use pip2 or pip2.x,
     where x matches the python minor version Ansible is running under.
@@ -316,7 +316,7 @@ be install using ``pip``:
 
 .. code-block:: shell
 
-    pip install pywinrm[kerberos]
+    pip install --no-cache-dir pywinrm[kerberos]
 
 
 Configuring Host Kerberos
@@ -465,7 +465,7 @@ The ``requests-credssp`` wrapper can be installed using ``pip``:
 
 .. code-block:: bash
 
-    pip install pywinrm[credssp]
+    pip install --no-cache-dir pywinrm[credssp]
 
 CredSSP and TLS 1.2
 +++++++++++++++++++
@@ -686,7 +686,7 @@ would an IPv4 address or hostname::
 
 .. Note:: The ipaddress library is only included by default in Python 3.x. To
     use IPv6 addresses in Python 2.6 and 2.7, make sure to run
-    ``pip install ipaddress`` which installs a backported package.
+    ``pip install --no-cache-dir ipaddress`` which installs a backported package.
 
 HTTPS Certificate Validation
 ````````````````````````````

--- a/hacking/README.md
+++ b/hacking/README.md
@@ -17,7 +17,7 @@ and do not wish to install them from your operating system package manager, you
 can install them from pip
 
     $ easy_install pip               # if pip is not already available
-    $ pip install -r requirements.txt
+    $ pip install --no-cache-dir -r requirements.txt
 
 From there, follow ansible instructions on docs.ansible.com as normal.
 

--- a/lib/ansible/galaxy/data/container/.travis.yml
+++ b/lib/ansible/galaxy/data/container/.travis.yml
@@ -12,8 +12,8 @@ before_install:
 
 install:
   # Install the latest Ansible Container and Ansible
-  - pip install git+https://github.com/ansible/ansible-container.git
-  - pip install ansible
+  - pip install --no-cache-dir git+https://github.com/ansible/ansible-container.git
+  - pip install --no-cache-dir ansible
 
 script:
   # Make sure docker is functioning

--- a/lib/ansible/galaxy/data/default/.travis.yml
+++ b/lib/ansible/galaxy/data/default/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install --no-cache-dir ansible
 
   # Check ansible version
   - ansible --version

--- a/lib/ansible/galaxy/data/network/.travis.yml
+++ b/lib/ansible/galaxy/data/network/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install --no-cache-dir ansible
 
   # Check ansible version
   - ansible --version

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -253,15 +253,15 @@ class AzureRMModuleBase(object):
                                     required_if=merged_required_if)
 
         if not HAS_PACKAGING_VERSION:
-            self.fail("Do you have packaging installed? Try `pip install packaging`"
+            self.fail("Do you have packaging installed? Try `pip install --no-cache-dir packaging`"
                       "- {0}".format(HAS_PACKAGING_VERSION_EXC))
 
         if not HAS_MSRESTAZURE:
-            self.fail("Do you have msrestazure installed? Try `pip install msrestazure`"
+            self.fail("Do you have msrestazure installed? Try `pip install --no-cache-dir msrestazure`"
                       "- {0}".format(HAS_MSRESTAZURE_EXC))
 
         if not HAS_AZURE:
-            self.fail("Do you have azure>={1} installed? Try `pip install ansible[azure]`"
+            self.fail("Do you have azure>={1} installed? Try `pip install --no-cache-dir ansible[azure]`"
                       "- {0}".format(HAS_AZURE_EXC, AZURE_MIN_RELEASE))
 
         self._cloud_environment = None
@@ -409,10 +409,10 @@ class AzureRMModuleBase(object):
             expected_version = package_version.get('expected_version')
             if Version(client_version) < Version(expected_version):
                 self.fail("Installed azure-mgmt-{0} client version is {1}. The minimum supported version is {2}. Try "
-                          "`pip install ansible[azure]`".format(client_name, client_version, expected_version))
+                          "`pip install --no-cache-dir ansible[azure]`".format(client_name, client_version, expected_version))
             if Version(client_version) != Version(expected_version):
                 self.module.warn("Installed azure-mgmt-{0} client version is {1}. The expected version is {2}. Try "
-                                 "`pip install ansible[azure]`".format(client_name, client_version, expected_version))
+                                 "`pip install --no-cache-dir ansible[azure]`".format(client_name, client_version, expected_version))
 
     def exec_module(self, **kwargs):
         self.fail("Error: {0} failed to implement exec_module method.".format(self.__class__.__name__))
@@ -602,7 +602,7 @@ class AzureRMModuleBase(object):
 
         if auth_source == 'cli':
             if not HAS_AZURE_CLI_CORE:
-                self.fail("Azure auth_source is `cli`, but azure-cli package is not available. Try `pip install azure-cli --upgrade`")
+                self.fail("Azure auth_source is `cli`, but azure-cli package is not available. Try `pip install --no-cache-dir azure-cli --upgrade`")
             try:
                 self.log('Retrieving credentials from Azure CLI profile')
                 cli_credentials = self._get_azure_cli_credentials()

--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -53,7 +53,7 @@ class AnsibleCloudStack:
 
     def __init__(self, module):
         if not HAS_LIB_CS:
-            module.fail_json(msg="python library cs required: pip install cs")
+            module.fail_json(msg="python library cs required: pip install --no-cache-dir cs")
 
         self.result = {
             'changed': False,

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -170,7 +170,7 @@ class AnsibleDockerClient(Client):
                       "cause a corrupt installation. Please uninstall both packages, and re-install only the docker-py or docker python module")
 
         if not HAS_DOCKER_PY:
-            self.fail("Failed to import docker-py - %s. Try `pip install docker-py`" % HAS_DOCKER_ERROR)
+            self.fail("Failed to import docker-py - %s. Try `pip install --no-cache-dir docker-py`" % HAS_DOCKER_ERROR)
 
         if LooseVersion(docker_version) < LooseVersion(MIN_DOCKER_VERSION):
             self.fail("Error: docker-py version is %s. Minimum version required is %s." % (docker_version,

--- a/lib/ansible/module_utils/heroku.py
+++ b/lib/ansible/module_utils/heroku.py
@@ -22,7 +22,7 @@ class HerokuHelper():
 
     def check_lib(self):
         if not HAS_HEROKU:
-            self.module.fail_json(msg='heroku3 library required for this module (pip install heroku3)')
+            self.module.fail_json(msg='heroku3 library required for this module (pip install --no-cache-dir heroku3)')
 
     @staticmethod
     def heroku_argument_spec():

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -243,10 +243,10 @@ class KubernetesAnsibleModule(AnsibleModule, K8sAnsibleMixin):
         AnsibleModule.__init__(self, *args, **kwargs)
 
         if not HAS_K8S_MODULE_HELPER:
-            self.fail_json(msg="This module requires the OpenShift Python client. Try `pip install openshift`")
+            self.fail_json(msg="This module requires the OpenShift Python client. Try `pip install --no-cache-dir openshift`")
 
         if not HAS_YAML:
-            self.fail_json(msg="This module requires PyYAML. Try `pip install PyYAML`")
+            self.fail_json(msg="This module requires PyYAML. Try `pip install --no-cache-dir PyYAML`")
 
     def execute_module(self):
         raise NotImplementedError()

--- a/lib/ansible/module_utils/k8s/inventory.py
+++ b/lib/ansible/module_utils/k8s/inventory.py
@@ -44,7 +44,7 @@ class K8sInventoryHelper(K8sAnsibleMixin):
 
         if not HAS_K8S_MODULE_HELPER:
             raise K8sInventoryException(
-                "This module requires the OpenShift Python client. Try `pip install openshift`"
+                "This module requires the OpenShift Python client. Try `pip install --no-cache-dir openshift`"
             )
 
         source_data = None

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -71,7 +71,7 @@ def get_connector(*args, **kwargs):
     if not HAS_INFOBLOX_CLIENT:
         raise Exception('infoblox-client is required but does not appear '
                         'to be installed.  It can be installed using the '
-                        'command `pip install infoblox-client`')
+                        'command `pip install --no-cache-dir infoblox-client`')
 
     if not set(kwargs.keys()).issubset(NIOS_PROVIDER_SPEC.keys()):
         raise Exception('invalid or unsupported keyword argument for connector')

--- a/lib/ansible/module_utils/network/common/netconf.py
+++ b/lib/ansible/module_utils/network/common/netconf.py
@@ -137,5 +137,5 @@ def transform_reply():
 def remove_namespaces(data):
     if not HAS_NCCLIENT:
         raise ImportError("ncclient is required but does not appear to be installed.  "
-                          "It can be installed using `pip install ncclient`")
+                          "It can be installed using `pip install --no-cache-dir ncclient`")
     return NCElement(data, transform_reply()).data_xml

--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -410,7 +410,7 @@ class Template:
     def __init__(self):
         if not HAS_JINJA2:
             raise ImportError("jinja2 is required but does not appear to be installed.  "
-                              "It can be installed using `pip install jinja2`")
+                              "It can be installed using `pip install --no-cache-dir jinja2`")
 
         self.env = Environment(undefined=StrictUndefined)
         self.env.filters.update({'ternary': ternary})

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -764,7 +764,7 @@ class PyVmomi(object):
         Constructor
         """
         if not HAS_PYVMOMI:
-            module.fail_json(msg='PyVmomi Python module required. Install using "pip install PyVmomi"')
+            module.fail_json(msg='PyVmomi Python module required. Install using "pip install --no-cache-dir PyVmomi"')
 
         self.module = module
         self.params = module.params

--- a/lib/ansible/module_utils/vmware_rest_client.py
+++ b/lib/ansible/module_utils/vmware_rest_client.py
@@ -57,9 +57,9 @@ class VmwareRestClient(object):
         """
         if not HAS_REQUESTS:
             self.module.fail_json(msg="Unable to find 'requests' Python library which is required."
-                                      " Please install using 'pip install requests'")
+                                      " Please install using 'pip install --no-cache-dir requests'")
         if not HAS_PYVMOMI:
-            self.module.fail_json(msg="PyVmomi Python module required. Install using 'pip install PyVmomi'")
+            self.module.fail_json(msg="PyVmomi Python module required. Install using 'pip install --no-cache-dir PyVmomi'")
         if not HAS_VSPHERE:
             self.module.fail_json(msg="Unable to find 'vSphere Automation SDK' Python library which is required."
                                       " Please refer this URL for installation steps"

--- a/lib/ansible/modules/cloud/alicloud/ali_slb_server.py
+++ b/lib/ansible/modules/cloud/alicloud/ali_slb_server.py
@@ -380,7 +380,7 @@ def main():
 
     if HAS_FOOTMARK is False:
         module.fail_json(msg="'footmark' is required for the module ali_slb_server. "
-                             "Please install 'footmark' by using 'sudo pip install footmark'.")
+                             "Please install 'footmark' by using 'sudo pip install --no-cache-dir footmark'.")
 
     # handling region parameter which is required by common utils file to login but not required by this module
     module.params['alicloud_region'] = 'cn-hangzhou'

--- a/lib/ansible/modules/database/misc/redis.py
+++ b/lib/ansible/modules/database/misc/redis.py
@@ -70,7 +70,7 @@ options:
 
 notes:
    - Requires the redis-py Python package on the remote host. You can
-     install it with pip (pip install redis) or with a package manager.
+     install it with pip (pip install --no-cache-dir redis) or with a package manager.
      https://github.com/andymccurdy/redis-py
    - If the redis master instance we are making slave of is password protected
      this needs to be in the redis.conf in the masterauth variable

--- a/lib/ansible/modules/database/mssql/mssql_db.py
+++ b/lib/ansible/modules/database/mssql/mssql_db.py
@@ -57,7 +57,7 @@ options:
     default: 'no'
 notes:
    - Requires the pymssql Python package on the remote host. For Ubuntu, this
-     is as easy as pip install pymssql (See M(pip).)
+     is as easy as pip install --no-cache-dir pymssql (See M(pip).)
 requirements:
    - python >= 2.7
    - pymssql

--- a/lib/ansible/modules/messaging/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq_binding.py
@@ -296,7 +296,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json(msg="requests library is required for this module. To install, use `pip install requests`")
+        module.fail_json(msg="requests library is required for this module. To install, use `pip install --no-cache-dir requests`")
 
     RabbitMqBinding(module).run()
 

--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -145,7 +145,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json(msg="requests library is required for this module. To install, use `pip install requests`")
+        module.fail_json(msg="requests library is required for this module. To install, use `pip install --no-cache-dir requests`")
 
     # Check if exchange already exists
     r = requests.get(url, auth=(module.params['login_user'], module.params['login_password']))

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -153,7 +153,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json(msg="requests library is required for this module. To install, use `pip install requests`")
+        module.fail_json(msg="requests library is required for this module. To install, use `pip install --no-cache-dir requests`")
 
     result = dict(changed=False, name=module.params['name'])
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
@@ -146,7 +146,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_facts.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_facts.py
@@ -104,7 +104,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing requried zabbix-api module (check docs or install with: pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -656,7 +656,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
@@ -162,7 +162,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -170,7 +170,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
@@ -74,7 +74,7 @@ notes:
     - Module creates maintenance window from now() to now() + minutes,
       so if Zabbix server's time and host's time are not synchronized,
       you will get strange results.
-    - Install required module with 'pip install zabbix-api' command.
+    - Install required module with 'pip install --no-cache-dir zabbix-api' command.
 '''
 
 EXAMPLES = '''
@@ -282,7 +282,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install --no-cache-dir zabbix-api)")
 
     host_names = module.params['host_names']
     host_groups = module.params['host_groups']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
@@ -261,7 +261,7 @@ def main():
     if not HAS_ZABBIX_API:
         module.fail_json(msg="Missing requried zabbix-api module" +
                              " (check docs or install with:" +
-                             " pip install zabbix-api)")
+                             " pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -319,7 +319,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -459,7 +459,7 @@ def main():
     if not HAS_ZABBIX_API:
         module.fail_json(msg="Missing required zabbix-api module " +
                              "(check docs or install with: " +
-                             "pip install zabbix-api)")
+                             "pip install --no-cache-dir zabbix-api)")
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -247,7 +247,7 @@ def main():
 
     if not HAS_LDAP:
         module.fail_json(
-            msg="Missing required 'ldap' module (pip install python-ldap)")
+            msg="Missing required 'ldap' module (pip install --no-cache-dir python-ldap)")
 
     # Update module parameters with user's parameters if defined
     if 'params' in module.params and isinstance(module.params['params'], dict):

--- a/lib/ansible/modules/net_tools/ldap/ldap_entry.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_entry.py
@@ -200,7 +200,7 @@ def main():
 
     if not HAS_LDAP:
         module.fail_json(
-            msg="Missing required 'ldap' module (pip install python-ldap).")
+            msg="Missing required 'ldap' module (pip install --no-cache-dir python-ldap).")
 
     state = module.params['state']
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -133,7 +133,7 @@ def main():
 
     if not HAS_LDAP:
         module.fail_json(
-            msg="Missing required 'ldap' module (pip install python-ldap).")
+            msg="Missing required 'ldap' module (pip install --no-cache-dir python-ldap).")
 
     ldap = LdapPasswd(module)
 

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -342,7 +342,7 @@ def main():
     )
 
     if not HAVE_DNSPYTHON:
-        module.fail_json(msg='python library dnspython required: pip install dnspython')
+        module.fail_json(msg='python library dnspython required: pip install --no-cache-dir dnspython')
 
     if len(module.params["record"]) == 0:
         module.fail_json(msg='record cannot be empty.')

--- a/lib/ansible/modules/network/f5/bigip_configsync_action.py
+++ b/lib/ansible/modules/network/f5/bigip_configsync_action.py
@@ -48,7 +48,7 @@ options:
     type: bool
 notes:
   - Requires the objectpath Python package on the host. This is as easy as
-    C(pip install objectpath).
+    C(pip install --no-cache-dir objectpath).
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)

--- a/lib/ansible/modules/network/f5/bigip_device_httpd.py
+++ b/lib/ansible/modules/network/f5/bigip_device_httpd.py
@@ -90,7 +90,7 @@ options:
     version_added: 2.6
 notes:
   - Requires the requests Python package on the host. This is as easy as
-    C(pip install requests).
+    C(pip install --no-cache-dir requests).
 requirements:
   - requests
 extends_documentation_fragment: f5

--- a/lib/ansible/modules/network/f5/bigip_gtm_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool.py
@@ -179,7 +179,7 @@ options:
     version_added: 2.6
 notes:
   - Requires the netaddr Python package on the host. This is as easy as
-    pip install netaddr.
+    pip install --no-cache-dir netaddr.
 extends_documentation_fragment: f5
 requirements:
   - netaddr

--- a/lib/ansible/modules/network/f5/bigip_node.py
+++ b/lib/ansible/modules/network/f5/bigip_node.py
@@ -142,7 +142,7 @@ options:
     version_added: 2.5
 notes:
   - Requires the netaddr Python package on the host. This is as easy as
-    C(pip install netaddr).
+    C(pip install --no-cache-dir netaddr).
 requirements:
   - netaddr
 extends_documentation_fragment: f5

--- a/lib/ansible/modules/network/f5/bigip_smtp.py
+++ b/lib/ansible/modules/network/f5/bigip_smtp.py
@@ -95,7 +95,7 @@ options:
 extends_documentation_fragment: f5
 notes:
   - Requires the netaddr Python package on the host. This is as easy as
-    C(pip install netaddr).
+    C(pip install --no-cache-dir netaddr).
 requirements:
   - netaddr
 author:

--- a/lib/ansible/modules/network/f5/bigip_snat_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_snat_pool.py
@@ -43,7 +43,7 @@ options:
     version_added: 2.5
 notes:
    - Requires the netaddr Python package on the host. This is as easy as
-     pip install netaddr
+     pip install --no-cache-dir netaddr
 extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)

--- a/lib/ansible/modules/network/f5/bigip_snmp.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp.py
@@ -63,7 +63,7 @@ options:
 extends_documentation_fragment: f5
 notes:
   - Requires the netaddr Python package on the host. This is as easy as
-    C(pip install netaddr).
+    C(pip install --no-cache-dir netaddr).
 requirements:
   - netaddr
 author:

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -671,12 +671,12 @@ def main():
         if not HAS_B64:
             module.fail_json(
                 msg='library base64 is required but does not appear to be '
-                    'installed. It can be installed using `pip install base64`'
+                    'installed. It can be installed using `pip install --no-cache-dir base64`'
             )
         if not HAS_PARAMIKO:
             module.fail_json(
                 msg='library paramiko is required but does not appear to be '
-                    'installed. It can be installed using `pip install paramiko`'
+                    'installed. It can be installed using `pip install --no-cache-dir paramiko`'
             )
 
     result = {'changed': False, 'warnings': []}

--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -398,7 +398,7 @@ def main():
             if item['xattrs']['format'] == 'xml':
                 if not HAS_JXMLEASE:
                     module.fail_json(msg='jxmlease is required but does not appear to be installed. '
-                                         'It can be installed using `pip install jxmlease`')
+                                         'It can be installed using `pip install --no-cache-dir jxmlease`')
 
                 try:
                     json_resp = jxmlease.parse(resp)

--- a/lib/ansible/modules/network/junos/junos_scp.py
+++ b/lib/ansible/modules/network/junos/junos_scp.py
@@ -154,7 +154,7 @@ def main():
     if not HAS_PYEZ:
         module.fail_json(
             msg='junos-eznc is required but does not appear to be installed. '
-                'It can be installed using `pip install junos-eznc`'
+                'It can be installed using `pip install --no-cache-dir junos-eznc`'
         )
 
     result = dict(changed=True)

--- a/lib/ansible/modules/network/netconf/netconf_get.py
+++ b/lib/ansible/modules/network/netconf/netconf_get.py
@@ -225,7 +225,7 @@ def main():
     if display == 'json' and not HAS_JXMLEASE:
         module.fail_json(msg='jxmlease is required to display response in json format'
                              'but does not appear to be installed. '
-                             'It can be installed using `pip install jxmlease`')
+                             'It can be installed using `pip install --no-cache-dir jxmlease`')
 
     filter_spec = (filter_type, filter) if filter_type else None
 

--- a/lib/ansible/modules/network/netconf/netconf_rpc.py
+++ b/lib/ansible/modules/network/netconf/netconf_rpc.py
@@ -189,7 +189,7 @@ def get_xml_request(module, request, xmlns, content):
         if not HAS_JXMLEASE:
             module.fail_json(msg='jxmlease is required to convert RPC content to XML '
                                  'but does not appear to be installed. '
-                                 'It can be installed using `pip install jxmlease`')
+                                 'It can be installed using `pip install --no-cache-dir jxmlease`')
 
         payload = jxmlease.XMLDictNode(content).emit_xml(pretty=False, full_document=False)
         if xmlns is None:
@@ -233,7 +233,7 @@ def main():
     if display == 'json' and not HAS_JXMLEASE:
         module.fail_json(msg='jxmlease is required to display response in json format'
                              'but does not appear to be installed. '
-                             'It can be installed using `pip install jxmlease`')
+                             'It can be installed using `pip install --no-cache-dir jxmlease`')
 
     xml_req = get_xml_request(module, rpc, xmlns, content)
     response = dispatch(module, xml_req)

--- a/lib/ansible/modules/network/nxos/_nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/_nxos_ip_interface.py
@@ -521,7 +521,7 @@ def main():
                            supports_check_mode=True)
 
     if not HAS_IPADDRESS:
-        module.fail_json(msg="ipaddress is required for this module. Run 'pip install ipaddress' for install.")
+        module.fail_json(msg="ipaddress is required for this module. Run 'pip install --no-cache-dir ipaddress' for install.")
 
     warnings = list()
 

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -200,13 +200,13 @@ def main():
     if not HAS_PARAMIKO:
         module.fail_json(
             msg='library paramiko is required but does not appear to be '
-                'installed. It can be installed using `pip install paramiko`'
+                'installed. It can be installed using `pip install --no-cache-dir paramiko`'
         )
 
     if not HAS_SCP:
         module.fail_json(
             msg='library scp is required but does not appear to be '
-                'installed. It can be installed using `pip install scp`'
+                'installed. It can be installed using `pip install --no-cache-dir scp`'
         )
 
     warnings = list()

--- a/lib/ansible/modules/network/radware/vdirect_commit.py
+++ b/lib/ansible/modules/network/radware/vdirect_commit.py
@@ -40,7 +40,7 @@ description:
       Explicit apply, sync and save actions specifying is not relevant.
 notes:
     - Requires the Radware vdirect-client Python package on the host. This is as easy as
-      C(pip install vdirect-client)
+      C(pip install --no-cache-dir vdirect-client)
 version_added: "2.5"
 options:
   vdirect_ip:

--- a/lib/ansible/modules/network/radware/vdirect_file.py
+++ b/lib/ansible/modules/network/radware/vdirect_file.py
@@ -34,7 +34,7 @@ description:
       All parameters may be set as environment variables.
 notes:
     - Requires the Radware vdirect-client Python package on the host. This is as easy as
-      C(pip install vdirect-client)
+      C(pip install --no-cache-dir vdirect-client)
 version_added: "2.4"
 options:
   vdirect_ip:

--- a/lib/ansible/modules/network/radware/vdirect_runnable.py
+++ b/lib/ansible/modules/network/radware/vdirect_runnable.py
@@ -34,7 +34,7 @@ description:
     - Runs configuration templates, creates workflows and runs workflow actions in Radware vDirect server.
 notes:
     - Requires the Radware vdirect-client Python package on the host. This is as easy as
-      C(pip install vdirect-client)
+      C(pip install --no-cache-dir vdirect-client)
 version_added: "2.5"
 options:
   vdirect_ip:

--- a/lib/ansible/modules/notification/pushbullet.py
+++ b/lib/ansible/modules/notification/pushbullet.py
@@ -51,7 +51,7 @@ options:
 
 notes:
    - Requires pushbullet.py Python package on the remote host.
-     You can install it via pip with ($ pip install pushbullet.py).
+     You can install it via pip with ($ pip install --no-cache-dir pushbullet.py).
      See U(https://github.com/randomchars/pushbullet.py)
 '''
 
@@ -125,7 +125,7 @@ def main():
     url = module.params['url']
 
     if not pushbullet_found:
-        module.fail_json(msg="Python 'pushbullet.py' module is required. Install via: $ pip install pushbullet.py")
+        module.fail_json(msg="Python 'pushbullet.py' module is required. Install via: $ pip install --no-cache-dir pushbullet.py")
 
     # Init pushbullet
     try:

--- a/lib/ansible/modules/notification/sendgrid.py
+++ b/lib/ansible/modules/notification/sendgrid.py
@@ -28,7 +28,7 @@ notes:
      dependency to work. In this case, you'll need an active SendGrid
      account."
    - "In order to use api_key, cc, bcc, attachments, from_name, html_body, headers
-     you must pip install sendgrid"
+     you must pip install --no-cache-dir sendgrid"
    - "since 2.2 username and password are not required if you supply an api_key"
 requirements:
   - sendgrid python library

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -98,7 +98,7 @@ options:
     description:
       - The system umask to apply before installing the pip package. This is
         useful, for example, when installing on systems that have a very
-        restrictive umask by default (e.g., 0077) and you want to pip install
+        restrictive umask by default (e.g., 0077) and you want to pip install --no-cache-dir
         packages which are to be used by all users. Note that this requires you
         to specify desired umask mode in octal, with a leading 0 (e.g., 0077).
     version_added: "2.1"
@@ -195,7 +195,7 @@ cmd:
   description: pip command used by the module
   returned: success
   type: string
-  sample: pip2 install ansible six
+  sample: pip2 install --no-cache-dir ansible six
 name:
   description: list of python modules targetted by pip
   returned: success

--- a/lib/ansible/modules/remote_management/foreman/foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/foreman.py
@@ -118,7 +118,7 @@ def main():
     )
 
     if not HAS_NAILGUN_PACKAGE:
-        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install nailgun")
+        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install --no-cache-dir nailgun")
 
     server_url = module.params['server_url']
     username = module.params['username']

--- a/lib/ansible/modules/remote_management/foreman/katello.py
+++ b/lib/ansible/modules/remote_management/foreman/katello.py
@@ -457,7 +457,7 @@ def main():
     )
 
     if not HAS_NAILGUN_PACKAGE:
-        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install nailgun")
+        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install --no-cache-dir nailgun")
 
     server_url = module.params['server_url']
     username = module.params['username']

--- a/lib/ansible/modules/source_control/github_issue.py
+++ b/lib/ansible/modules/source_control/github_issue.py
@@ -89,7 +89,7 @@ def main():
 
     if not HAS_GITHUB_PACKAGE:
         module.fail_json(msg="Missing required github3 module. (check docs or "
-                             "install with: pip install github3.py==1.0.0a4)")
+                             "install with: pip install --no-cache-dir github3.py==1.0.0a4)")
 
     organization = module.params['organization']
     repo = module.params['repo']

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -156,7 +156,7 @@ def main():
 
     if not HAS_GITHUB_API:
         module.fail_json(msg='Missing required github3 module (check docs or '
-                             'install with: pip install github3.py==1.0.0a4)')
+                             'install with: pip install --no-cache-dir github3.py==1.0.0a4)')
 
     repo = module.params['repo']
     user = module.params['user']

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -186,7 +186,7 @@ def main():
     )
 
     if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg="Missing requried gitlab module (check docs or install with: pip install python-gitlab")
+        module.fail_json(msg="Missing requried gitlab module (check docs or install with: pip install --no-cache-dir python-gitlab")
 
     server_url = module.params['server_url']
     validate_certs = module.params['validate_certs']

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -306,7 +306,7 @@ def main():
     )
 
     if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg="Missing required gitlab module (check docs or install with: pip install pyapi-gitlab")
+        module.fail_json(msg="Missing required gitlab module (check docs or install with: pip install --no-cache-dir pyapi-gitlab")
 
     server_url = module.params['server_url']
     verify_ssl = module.params['validate_certs']

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -270,7 +270,7 @@ def main():
     )
 
     if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg="Missing required gitlab module (check docs or install with: pip install pyapi-gitlab")
+        module.fail_json(msg="Missing required gitlab module (check docs or install with: pip install --no-cache-dir pyapi-gitlab")
 
     server_url = module.params['server_url']
     verify_ssl = module.params['validate_certs']

--- a/lib/ansible/plugins/cache/mongodb.py
+++ b/lib/ansible/plugins/cache/mongodb.py
@@ -54,7 +54,7 @@ from ansible.plugins.cache import BaseCacheModule
 try:
     import pymongo
 except ImportError:
-    raise AnsibleError("The 'pymongo' python module is required for the mongodb fact cache, 'pip install pymongo>=3.0'")
+    raise AnsibleError("The 'pymongo' python module is required for the mongodb fact cache, 'pip install --no-cache-dir pymongo>=3.0'")
 
 
 class CacheModule(BaseCacheModule):

--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -50,7 +50,7 @@ from ansible.plugins.cache import BaseCacheModule
 try:
     from redis import StrictRedis
 except ImportError:
-    raise AnsibleError("The 'redis' python module is required for the redis fact cache, 'pip install redis'")
+    raise AnsibleError("The 'redis' python module is required for the redis fact cache, 'pip install --no-cache-dir redis'")
 
 
 class CacheModule(BaseCacheModule):

--- a/lib/ansible/plugins/callback/jabber.py
+++ b/lib/ansible/plugins/callback/jabber.py
@@ -62,7 +62,7 @@ class CallbackModule(CallbackBase):
 
         if not HAS_XMPP:
             self._display.warning("The required python xmpp library (xmpppy) is not installed. "
-                                  "pip install git+https://github.com/ArchipelProject/xmpppy")
+                                  "pip install --no-cache-dir git+https://github.com/ArchipelProject/xmpppy")
             self.disabled = True
 
         self.serv = os.getenv('JABBER_SERV')

--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -86,7 +86,7 @@ class CallbackModule(CallbackBase):
         if not HAS_LOGSTASH:
             self.disabled = True
             self._display.warning("The required python-logstash is not installed. "
-                                  "pip install python-logstash")
+                                  "pip install --no-cache-dir python-logstash")
         else:
             self.logger = logging.getLogger('python-logstash-logger')
             self.logger.setLevel(logging.DEBUG)

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -311,7 +311,7 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         ssh = self._connection.paramiko_conn._connect_uncached()
         if proto == 'scp':
             if not HAS_SCP:
-                raise AnsibleError("Required library scp is not installed.  Please install it using `pip install scp`")
+                raise AnsibleError("Required library scp is not installed.  Please install it using `pip install --no-cache-dir scp`")
             with SCPClient(ssh.get_transport(), socket_timeout=timeout) as scp:
                 out = scp.put(source, destination)
         elif proto == 'sftp':
@@ -332,7 +332,7 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         ssh = self._connection.paramiko_conn._connect_uncached()
         if proto == 'scp':
             if not HAS_SCP:
-                raise AnsibleError("Required library scp is not installed.  Please install it using `pip install scp`")
+                raise AnsibleError("Required library scp is not installed.  Please install it using `pip install --no-cache-dir scp`")
             with SCPClient(ssh.get_transport(), socket_timeout=timeout) as scp:
                 scp.get(source, destination)
         elif proto == 'sftp':

--- a/lib/ansible/plugins/lookup/_openshift.py
+++ b/lib/ansible/plugins/lookup/_openshift.py
@@ -219,12 +219,12 @@ class KubernetesLookup(K8sAnsibleMixin):
 
         if not HAS_K8S_MODULE_HELPER:
             raise Exception(
-                "Requires the OpenShift Python client. Try `pip install openshift`"
+                "Requires the OpenShift Python client. Try `pip install --no-cache-dir openshift`"
             )
 
         if not HAS_YAML:
             raise Exception(
-                "Requires PyYAML. Try `pip install PyYAML`"
+                "Requires PyYAML. Try `pip install --no-cache-dir PyYAML`"
             )
 
         self.kind = None

--- a/lib/ansible/plugins/lookup/chef_databag.py
+++ b/lib/ansible/plugins/lookup/chef_databag.py
@@ -15,7 +15,7 @@ DOCUMENTATION = """
          The lookup order mirrors the one from Chef, all folders in the base path are walked back looking for the following configuration
          file in order : .chef/knife.rb, ~/.chef/knife.rb, /etc/chef/client.rb"
     requirements:
-        - "pychef (python library https://pychef.readthedocs.io `pip install pychef`"
+        - "pychef (python library https://pychef.readthedocs.io `pip install --no-cache-dir pychef`"
     options:
         name:
           description:
@@ -85,7 +85,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         # Ensure pychef has been loaded
         if not HAS_CHEF:
-            raise AnsibleError('PyChef needed for lookup plugin, try `pip install pychef`')
+            raise AnsibleError('PyChef needed for lookup plugin, try `pip install --no-cache-dir pychef`')
 
         for term in terms:
             self.parse_kv_args(parse_kv(term))

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -212,7 +212,7 @@ class HashiVault:
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         if not HAS_HVAC:
-            raise AnsibleError("Please pip install hvac to use the hashi_vault lookup module.")
+            raise AnsibleError("Please pip install --no-cache-dir hvac to use the hashi_vault lookup module.")
 
         vault_args = terms[0].split(' ')
         vault_dict = {}

--- a/lib/ansible/plugins/lookup/k8s.py
+++ b/lib/ansible/plugins/lookup/k8s.py
@@ -219,12 +219,12 @@ class KubernetesLookup(K8sAnsibleMixin):
 
         if not HAS_K8S_MODULE_HELPER:
             raise Exception(
-                "Requires the OpenShift Python client. Try `pip install openshift`"
+                "Requires the OpenShift Python client. Try `pip install --no-cache-dir openshift`"
             )
 
         if not HAS_YAML:
             raise Exception(
-                "Requires PyYAML. Try `pip install PyYAML`"
+                "Requires PyYAML. Try `pip install --no-cache-dir PyYAML`"
             )
 
         self.kind = None

--- a/lib/ansible/utils/module_docs_fragments/f5.py
+++ b/lib/ansible/utils/module_docs_fragments/f5.py
@@ -113,7 +113,7 @@ options:
 
 notes:
   - For more information on using Ansible to manage F5 Networks devices see U(https://www.ansible.com/integrations/networks/f5).
-  - Requires the f5-sdk Python package on the host. This is as easy as C(pip install f5-sdk).
+  - Requires the f5-sdk Python package on the host. This is as easy as C(pip install --no-cache-dir f5-sdk).
 requirements:
   - f5-sdk >= 3.0.9
 '''

--- a/lib/ansible/utils/module_docs_fragments/netapp.py
+++ b/lib/ansible/utils/module_docs_fragments/netapp.py
@@ -55,7 +55,7 @@ options:
 requirements:
   - A physical or virtual clustered Data ONTAP system. The modules were developed with Clustered Data ONTAP 9.3
   - Ansible 2.6
-  - netapp-lib (2017.10.30). Install using 'pip install netapp-lib'
+  - netapp-lib (2017.10.30). Install using 'pip install --no-cache-dir netapp-lib'
   - To enable http on the cluster you must run the following commands 'set -privilege advanced;' 'system services web modify -http-enabled true;'
 
 notes:
@@ -84,7 +84,7 @@ options:
 requirements:
   - A physical or virtual clustered Data ONTAP system. The modules were developed with Clustered Data ONTAP 8.3
   - Ansible 2.2
-  - netapp-lib (2015.9.25). Install using 'pip install netapp-lib'
+  - netapp-lib (2015.9.25). Install using 'pip install --no-cache-dir netapp-lib'
 
 notes:
   - The modules prefixed with na\\_cdot are built to support the ONTAP storage platform.

--- a/test/integration/targets/aws_eks/runme.sh
+++ b/test/integration/targets/aws_eks/runme.sh
@@ -15,11 +15,11 @@ PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 # Test graceful failure for older versions of botocore
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"
 source "${MYTMPDIR}/botocore-1.7.40/bin/activate"
-$PYTHON -m pip install 'botocore<1.10.0' boto3
+$PYTHON -m pip install --no-cache-dir 'botocore<1.10.0' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/old_version.yml "$@"
 
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.10.1' boto3
+$PYTHON -m pip install --no-cache-dir 'botocore>=1.10.1' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/connection_lxc/test_connection.inventory
+++ b/test/integration/targets/connection_lxc/test_connection.inventory
@@ -4,7 +4,7 @@ lxc-no-pipelining ansible_ssh_pipelining=false
 [lxc:vars]
 # 1. install lxc
 # 2. install python2-lxc
-# $ pip install git+https://github.com/lxc/python2-lxc.git
+# $ pip install --no-cache-dir git+https://github.com/lxc/python2-lxc.git
 # 3. create container:
 # $ sudo lxc-create -t download -n centos-7-amd64 -- -d centos -r 7 -a amd64
 # 4. start container:

--- a/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -400,7 +400,7 @@
     # ============================================================
     # FIXME - Replace by creating IPv6 enabled VPC once ec2_vpc_net module supports it.
     - name: install aws cli - FIXME temporary this should go for a lighterweight solution
-      command: pip install awscli
+      command: pip install --no-cache-dir awscli
 
     - name: Assign an Amazon provided IPv6 CIDR block to the VPC
       command: aws ec2 associate-vpc-cidr-block --amazon-provided-ipv6-cidr-block --vpc-id '{{ vpc_result.vpc.id }}'

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -15,18 +15,18 @@ PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 # Test graceful failure for older versions of botocore
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"
 source "${MYTMPDIR}/botocore-1.7.40/bin/activate"
-$PYTHON -m pip install 'botocore<=1.7.40' boto3
+$PYTHON -m pip install --no-cache-dir 'botocore<=1.7.40' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_fail.yml "$@"
 
 # Test graceful failure for assign public ip
 # applies for botocore >= 1.7.44 and < 1.8.4
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.44"
 source "${MYTMPDIR}/botocore-1.7.44/bin/activate"
-$PYTHON -m pip install 'botocore>=1.7.44,<1.8.4' boto3
+$PYTHON -m pip install --no-cache-dir 'botocore>=1.7.44,<1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/network_assign_public_ip_fail.yml "$@"
 
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.8.4' boto3
+$PYTHON -m pip install --no-cache-dir 'botocore>=1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/elb_target/runme.sh
+++ b/test/integration/targets/elb_target/runme.sh
@@ -15,12 +15,12 @@ PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 # Test graceful failure for older versions of botocore
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.1"
 source "${MYTMPDIR}/botocore-1.7.1/bin/activate"
-$PYTHON -m pip install 'botocore<=1.7.1' boto3
+$PYTHON -m pip install --no-cache-dir 'botocore<=1.7.1' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/version_fail.yml "$@"
 
 # Run full test suite
 virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
 source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.8.0' boto3
+$PYTHON -m pip install --no-cache-dir 'botocore>=1.8.0' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -e @../../cloud-config-aws.yml -v playbooks/full_test.yml "$@"
 

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -4,6 +4,6 @@ set -eux
 
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
-pip install jmespath
+pip install --no-cache-dir jmespath
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/groupby_filter/runme.sh
+++ b/test/integration/targets/groupby_filter/runme.sh
@@ -16,10 +16,10 @@ virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/jinja2"
 
 source "${MYTMPDIR}/jinja2/bin/activate"
 
-pip install -U jinja2==2.9.4
+pip install --no-cache-dir -U jinja2==2.9.4
 
 ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v "$@"
 
-pip install -U "jinja2<2.9.0"
+pip install --no-cache-dir -U "jinja2<2.9.0"
 
 ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v "$@"

--- a/test/integration/targets/lookups/runme.sh
+++ b/test/integration/targets/lookups/runme.sh
@@ -4,6 +4,6 @@ set -eux
 
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
-pip install passlib
+pip install --no-cache-dir passlib
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook lookups.yml -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -19,5 +19,5 @@ EOF
 ansible-playbook test-pause.yml -i ../../inventory "$@"
 
 # Interactively test pause
-pip install pexpect
+pip install --no-cache-dir pexpect
 python test-pause.py -i ../../inventory "$@"

--- a/test/integration/targets/template_jinja2_latest/runme.sh
+++ b/test/integration/targets/template_jinja2_latest/runme.sh
@@ -16,6 +16,6 @@ virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/jinja2"
 
 source "${MYTMPDIR}/jinja2/bin/activate"
 
-pip install -U jinja2
+pip install --no-cache-dir -U jinja2
 
 ansible-playbook -i ../../inventory main.yml -e @../../integration_config.yml -v "$@"

--- a/test/integration/targets/vault/runme_change_pip_installed.sh
+++ b/test/integration/targets/vault/runme_change_pip_installed.sh
@@ -8,7 +8,7 @@ pip uninstall -y pycrypto
 ./runme.sh
 
 # now just pycrypto
-pip install --user pycrypto
+pip install --no-cache-dir --user pycrypto
 
 ./runme.sh
 
@@ -16,12 +16,12 @@ pip install --user pycrypto
 # now just cryptography
 
 pip uninstall -y pycrypto
-pip install --user cryptography
+pip install --no-cache-dir --user cryptography
 
 ./runme.sh
 
 # now both
 
-pip install --user pycrypto
+pip install --no-cache-dir --user pycrypto
 
 ./runme.sh

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -43,7 +43,7 @@ elif [ "${platform}" = "rhel" ]; then
 fi
 
 if [ "${platform}" = "freebsd" ] || [ "${platform}" = "osx" ]; then
-    pip install virtualenv
+    pip install --no-cache-dir virtualenv
 
     # Tests assume loopback addresses other than 127.0.0.1 will work.
     # Add aliases for loopback addresses used by tests.

--- a/test/sanity/import/lib/ansible/module_utils/azure_rm_common.py
+++ b/test/sanity/import/lib/ansible/module_utils/azure_rm_common.py
@@ -253,15 +253,15 @@ class AzureRMModuleBase(object):
                                     required_if=merged_required_if)
 
         if not HAS_PACKAGING_VERSION:
-            self.fail("Do you have packaging installed? Try `pip install packaging`"
+            self.fail("Do you have packaging installed? Try `pip install --no-cache-dir packaging`"
                       "- {0}".format(HAS_PACKAGING_VERSION_EXC))
 
         if not HAS_MSRESTAZURE:
-            self.fail("Do you have msrestazure installed? Try `pip install msrestazure`"
+            self.fail("Do you have msrestazure installed? Try `pip install --no-cache-dir msrestazure`"
                       "- {0}".format(HAS_MSRESTAZURE_EXC))
 
         if not HAS_AZURE:
-            self.fail("Do you have azure>={1} installed? Try `pip install ansible[azure]`"
+            self.fail("Do you have azure>={1} installed? Try `pip install --no-cache-dir ansible[azure]`"
                       "- {0}".format(HAS_AZURE_EXC, AZURE_MIN_RELEASE))
 
         self._cloud_environment = None
@@ -409,10 +409,10 @@ class AzureRMModuleBase(object):
             expected_version = package_version.get('expected_version')
             if Version(client_version) < Version(expected_version):
                 self.fail("Installed azure-mgmt-{0} client version is {1}. The minimum supported version is {2}. Try "
-                          "`pip install ansible[azure]`".format(client_name, client_version, expected_version))
+                          "`pip install --no-cache-dir ansible[azure]`".format(client_name, client_version, expected_version))
             if Version(client_version) != Version(expected_version):
                 self.module.warn("Installed azure-mgmt-{0} client version is {1}. The expected version is {2}. Try "
-                                 "`pip install ansible[azure]`".format(client_name, client_version, expected_version))
+                                 "`pip install --no-cache-dir ansible[azure]`".format(client_name, client_version, expected_version))
 
     def exec_module(self, **kwargs):
         self.fail("Error: {0} failed to implement exec_module method.".format(self.__class__.__name__))
@@ -602,7 +602,7 @@ class AzureRMModuleBase(object):
 
         if auth_source == 'cli':
             if not HAS_AZURE_CLI_CORE:
-                self.fail("Azure auth_source is `cli`, but azure-cli package is not available. Try `pip install azure-cli --upgrade`")
+                self.fail("Azure auth_source is `cli`, but azure-cli package is not available. Try `pip install --no-cache-dir azure-cli --upgrade`")
             try:
                 self.log('Retrieving credentials from Azure CLI profile')
                 cli_credentials = self._get_azure_cli_credentials()

--- a/test/sanity/import/lib/ansible/module_utils/cloudstack.py
+++ b/test/sanity/import/lib/ansible/module_utils/cloudstack.py
@@ -53,7 +53,7 @@ class AnsibleCloudStack:
 
     def __init__(self, module):
         if not HAS_LIB_CS:
-            module.fail_json(msg="python library cs required: pip install cs")
+            module.fail_json(msg="python library cs required: pip install --no-cache-dir cs")
 
         self.result = {
             'changed': False,

--- a/test/sanity/import/lib/ansible/module_utils/docker_common.py
+++ b/test/sanity/import/lib/ansible/module_utils/docker_common.py
@@ -170,7 +170,7 @@ class AnsibleDockerClient(Client):
                       "cause a corrupt installation. Please uninstall both packages, and re-install only the docker-py or docker python module")
 
         if not HAS_DOCKER_PY:
-            self.fail("Failed to import docker-py - %s. Try `pip install docker-py`" % HAS_DOCKER_ERROR)
+            self.fail("Failed to import docker-py - %s. Try `pip install --no-cache-dir docker-py`" % HAS_DOCKER_ERROR)
 
         if LooseVersion(docker_version) < LooseVersion(MIN_DOCKER_VERSION):
             self.fail("Error: docker-py version is %s. Minimum version required is %s." % (docker_version,

--- a/test/sanity/import/lib/ansible/module_utils/heroku.py
+++ b/test/sanity/import/lib/ansible/module_utils/heroku.py
@@ -22,7 +22,7 @@ class HerokuHelper():
 
     def check_lib(self):
         if not HAS_HEROKU:
-            self.module.fail_json(msg='heroku3 library required for this module (pip install heroku3)')
+            self.module.fail_json(msg='heroku3 library required for this module (pip install --no-cache-dir heroku3)')
 
     @staticmethod
     def heroku_argument_spec():

--- a/test/sanity/import/lib/ansible/module_utils/k8s/common.py
+++ b/test/sanity/import/lib/ansible/module_utils/k8s/common.py
@@ -243,10 +243,10 @@ class KubernetesAnsibleModule(AnsibleModule, K8sAnsibleMixin):
         AnsibleModule.__init__(self, *args, **kwargs)
 
         if not HAS_K8S_MODULE_HELPER:
-            self.fail_json(msg="This module requires the OpenShift Python client. Try `pip install openshift`")
+            self.fail_json(msg="This module requires the OpenShift Python client. Try `pip install --no-cache-dir openshift`")
 
         if not HAS_YAML:
-            self.fail_json(msg="This module requires PyYAML. Try `pip install PyYAML`")
+            self.fail_json(msg="This module requires PyYAML. Try `pip install --no-cache-dir PyYAML`")
 
     def execute_module(self):
         raise NotImplementedError()

--- a/test/sanity/import/lib/ansible/module_utils/k8s/inventory.py
+++ b/test/sanity/import/lib/ansible/module_utils/k8s/inventory.py
@@ -44,7 +44,7 @@ class K8sInventoryHelper(K8sAnsibleMixin):
 
         if not HAS_K8S_MODULE_HELPER:
             raise K8sInventoryException(
-                "This module requires the OpenShift Python client. Try `pip install openshift`"
+                "This module requires the OpenShift Python client. Try `pip install --no-cache-dir openshift`"
             )
 
         source_data = None

--- a/test/sanity/import/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/test/sanity/import/lib/ansible/module_utils/net_tools/nios/api.py
@@ -71,7 +71,7 @@ def get_connector(*args, **kwargs):
     if not HAS_INFOBLOX_CLIENT:
         raise Exception('infoblox-client is required but does not appear '
                         'to be installed.  It can be installed using the '
-                        'command `pip install infoblox-client`')
+                        'command `pip install --no-cache-dir infoblox-client`')
 
     if not set(kwargs.keys()).issubset(NIOS_PROVIDER_SPEC.keys()):
         raise Exception('invalid or unsupported keyword argument for connector')

--- a/test/sanity/import/lib/ansible/module_utils/network/common/netconf.py
+++ b/test/sanity/import/lib/ansible/module_utils/network/common/netconf.py
@@ -137,5 +137,5 @@ def transform_reply():
 def remove_namespaces(data):
     if not HAS_NCCLIENT:
         raise ImportError("ncclient is required but does not appear to be installed.  "
-                          "It can be installed using `pip install ncclient`")
+                          "It can be installed using `pip install --no-cache-dir ncclient`")
     return NCElement(data, transform_reply()).data_xml

--- a/test/sanity/import/lib/ansible/module_utils/network/common/utils.py
+++ b/test/sanity/import/lib/ansible/module_utils/network/common/utils.py
@@ -410,7 +410,7 @@ class Template:
     def __init__(self):
         if not HAS_JINJA2:
             raise ImportError("jinja2 is required but does not appear to be installed.  "
-                              "It can be installed using `pip install jinja2`")
+                              "It can be installed using `pip install --no-cache-dir jinja2`")
 
         self.env = Environment(undefined=StrictUndefined)
         self.env.filters.update({'ternary': ternary})

--- a/test/sanity/import/lib/ansible/module_utils/vmware.py
+++ b/test/sanity/import/lib/ansible/module_utils/vmware.py
@@ -764,7 +764,7 @@ class PyVmomi(object):
         Constructor
         """
         if not HAS_PYVMOMI:
-            module.fail_json(msg='PyVmomi Python module required. Install using "pip install PyVmomi"')
+            module.fail_json(msg='PyVmomi Python module required. Install using "pip install --no-cache-dir PyVmomi"')
 
         self.module = module
         self.params = module.params

--- a/test/sanity/import/lib/ansible/module_utils/vmware_rest_client.py
+++ b/test/sanity/import/lib/ansible/module_utils/vmware_rest_client.py
@@ -57,9 +57,9 @@ class VmwareRestClient(object):
         """
         if not HAS_REQUESTS:
             self.module.fail_json(msg="Unable to find 'requests' Python library which is required."
-                                      " Please install using 'pip install requests'")
+                                      " Please install using 'pip install --no-cache-dir requests'")
         if not HAS_PYVMOMI:
-            self.module.fail_json(msg="PyVmomi Python module required. Install using 'pip install PyVmomi'")
+            self.module.fail_json(msg="PyVmomi Python module required. Install using 'pip install --no-cache-dir PyVmomi'")
         if not HAS_VSPHERE:
             self.module.fail_json(msg="Unable to find 'vSphere Automation SDK' Python library which is required."
                                       " Please refer this URL for installation steps"

--- a/test/units/cli/test_data/role_skeleton/.travis.yml
+++ b/test/units/cli/test_data/role_skeleton/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install --no-cache-dir ansible
 
   # Check ansible version
   - ansible --version

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -38,7 +38,7 @@ class FakeModule(object):
       sudo apt-get update
       sudo apt-get install python-setuptools git gcc python-dev libssl-dev
       sudo easy_install pip
-      sudo pip install ansible nose coverage
+      sudo pip install --no-cache-dir ansible nose coverage
       # git the module and cd to the directory
       nosetests --with-coverage --cover-package=nclu --cover-erase --cover-branches
 

--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -46,7 +46,7 @@ RUN yum clean all && \
     && \
     yum clean all
 
-RUN rpm -e --nodeps python-crypto && pip install --upgrade pycrypto cryptography
+RUN rpm -e --nodeps python-crypto && pip install --no-cache-dir --upgrade pycrypto cryptography
 
 RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
@@ -58,6 +58,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install coverage junit-xml
+RUN pip install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -65,6 +65,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install coverage junit-xml
+RUN pip install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -74,6 +74,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install coverage junit-xml
+RUN pip install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -70,6 +70,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install coverage junit-xml
+RUN pip install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora26py3/Dockerfile
+++ b/test/utils/docker/fedora26py3/Dockerfile
@@ -67,6 +67,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip3 install coverage junit-xml
+RUN pip3 install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora27py3/Dockerfile
+++ b/test/utils/docker/fedora27py3/Dockerfile
@@ -67,6 +67,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip3 install coverage junit-xml
+RUN pip3 install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/opensuse42.3/Dockerfile
+++ b/test/utils/docker/opensuse42.3/Dockerfile
@@ -73,6 +73,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 # explicitly enable the service, opensuse default to disabled services
 RUN systemctl enable sshd.service
-RUN pip install coverage junit-xml
+RUN pip install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -54,8 +54,8 @@ RUN apt-get update -y && \
     && \
     apt-get clean
 
-RUN pip install pip --upgrade
-RUN pip install --upgrade pycrypto cryptography
+RUN pip install --no-cache-dir pip --upgrade
+RUN pip install --no-cache-dir --upgrade pycrypto cryptography
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile
@@ -93,6 +93,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip install coverage junit-xml
+RUN pip install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -68,6 +68,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip install coverage junit-xml
+RUN pip install --no-cache-dir coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -64,6 +64,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip3 install coverage junit-xml python3-keyczar
+RUN pip3 install --no-cache-dir coverage junit-xml python3-keyczar
 ENV container=docker
 CMD ["/sbin/init"]


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6